### PR TITLE
Py3

### DIFF
--- a/pisa/analysis/analysis.py
+++ b/pisa/analysis/analysis.py
@@ -162,8 +162,7 @@ def validate_minimizer_settings(minimizer_settings):
                 raise ValueError(eps_msg % (method, s, val, err_lim, 'FTYPE',
                                             ftype_eps))
             if val < warn_lim * ftype_eps:
-                logging.warn(eps_msg, method, s, val, warn_lim, 'FTYPE',
-                             ftype_eps)
+                logging.warning(eps_msg, method, s, val, warn_lim, 'FTYPE', ftype_eps)
 
         val = options['eps']
         err_lim, warn_lim = 1, 10
@@ -171,14 +170,13 @@ def validate_minimizer_settings(minimizer_settings):
             raise ValueError(eps_msg % (method, 'eps', val, err_lim, 'FP64',
                                         fp64_eps))
         if val < warn_lim * ftype_eps:
-            logging.warn(eps_msg, method, 'eps', val, warn_lim, 'FTYPE',
-                         ftype_eps)
+            logging.warning(eps_msg, method, 'eps', val, warn_lim, 'FTYPE', ftype_eps)
 
         err_lim, warn_lim = 0.25, 0.1
         if val > err_lim:
             raise ValueError(eps_gt_msg % (method, 'eps', val, err_lim))
         if val > warn_lim:
-            logging.warn(eps_gt_msg, method, 'eps', val, warn_lim)
+            logging.warning(eps_gt_msg, method, 'eps', val, warn_lim)
 
     if method == 'slsqp':
         err_lim, warn_lim = 2, 10
@@ -187,8 +185,7 @@ def validate_minimizer_settings(minimizer_settings):
             raise ValueError(eps_msg % (method, 'ftol', val, err_lim, 'FTYPE',
                                         ftype_eps))
         if val < warn_lim * ftype_eps:
-            logging.warn(eps_msg, method, 'ftol', val, warn_lim, 'FTYPE',
-                         ftype_eps)
+            logging.warning(eps_msg, method, 'ftol', val, warn_lim, 'FTYPE', ftype_eps)
 
         val = options['eps']
         err_lim, warn_lim = 1, 10
@@ -196,14 +193,13 @@ def validate_minimizer_settings(minimizer_settings):
             raise ValueError(eps_msg % (method, 'eps', val, 1, 'FP64',
                                         fp64_eps))
         if val < warn_lim * ftype_eps:
-            logging.warn(eps_msg, method, 'eps', val, warn_lim, 'FP64',
-                         fp64_eps)
+            logging.warning(eps_msg, method, 'eps', val, warn_lim, 'FP64', fp64_eps)
 
         err_lim, warn_lim = 0.25, 0.1
         if val > err_lim:
             raise ValueError(eps_gt_msg % (method, 'eps', val, err_lim))
         if val > warn_lim:
-            logging.warn(eps_gt_msg, method, 'eps', val, warn_lim)
+            logging.warning(eps_gt_msg, method, 'eps', val, warn_lim)
 
 
 def check_t23_octant(fit_info):
@@ -672,13 +668,13 @@ class Analysis(object):
             clipped_x0.append(clipped_x0_val)
 
             if recursiveEquality(clipped_x0_val, bds[0]):
-                logging.warn(
+                logging.warning(
                     'Param %s, initial scaled value %e is at the lower bound;'
                     ' minimization may fail as a result.',
                     param.name, clipped_x0_val
                 )
             if recursiveEquality(clipped_x0_val, bds[1]):
-                logging.warn(
+                logging.warning(
                     'Param %s, initial scaled value %e is at the upper bound;'
                     ' minimization may fail as a result.',
                     param.name, clipped_x0_val

--- a/pisa/analysis/hypo_testing.py
+++ b/pisa/analysis/hypo_testing.py
@@ -342,7 +342,7 @@ class HypoTesting(Analysis):
                  allow_dirty=False, allow_no_git_info=False,
                  blind=False, store_minimizer_history=True, pprint=False,
                  reset_free=True, shared_params=None):
-        super(HypoTesting, self).__init__()
+        super().__init__()
 
         assert num_data_trials >= 1
         assert num_fid_trials >= 1
@@ -420,7 +420,7 @@ class HypoTesting(Analysis):
 
         # Ensure num_{fid_}data_trials is one if fluctuate_{fid_}data is False
         if not fluctuate_data and num_data_trials != 1:
-            logging.warn(
+            logging.warning(
                 'More than one data trial is unnecessary because'
                 ' `fluctuate_data` is False (i.e., all `num_data_trials` data'
                 ' distributions will be identical). Forcing `num_data_trials`'
@@ -429,7 +429,7 @@ class HypoTesting(Analysis):
             num_data_trials = 1
 
         if not fluctuate_fid and num_fid_trials != 1:
-            logging.warn(
+            logging.warning(
                 'More than one fid trial is unnecessary because'
                 ' `fluctuate_fid` is False (i.e., all'
                 ' `num_fid_trials` data distributions will be identical).'
@@ -1292,7 +1292,7 @@ class HypoTesting(Analysis):
         if no_git_info:
             msg = 'No info about git repo. Version info: %s' %self.version_info
             if self.allow_no_git_info:
-                logging.warn(msg)
+                logging.warning(msg)
             else:
                 raise Exception(msg)
 
@@ -1300,7 +1300,7 @@ class HypoTesting(Analysis):
         if dirty_git_repo:
             msg = 'Dirty git repo. Version info: %s' %self.version_info
             if self.allow_dirty:
-                logging.warn(msg)
+                logging.warning(msg)
             else:
                 raise Exception(msg)
 

--- a/pisa/analysis/hypo_testing.py
+++ b/pisa/analysis/hypo_testing.py
@@ -1488,7 +1488,7 @@ class HypoTesting(Analysis):
                 if env_var.startswith(prefix):
                     run_info.append('%s = %s' %(env_var, val))
 
-        with file(self.run_info_fpath, 'w') as f:
+        with open(self.run_info_fpath, 'w') as f:
             f.write('\n'.join(run_info) + '\n')
         logging.info('Run info written to: ' + self.run_info_fpath)
 
@@ -1528,7 +1528,7 @@ class HypoTesting(Analysis):
             )
             run_info.append('traceback = %s' %formatted_tb)
 
-        with file(self.run_info_fpath, 'a') as f:
+        with open(self.run_info_fpath, 'a') as f:
             f.write('\n'.join(run_info) + '\n')
 
         logging.info('Run stop info written to: ' + self.run_info_fpath)

--- a/pisa/core/binning.py
+++ b/pisa/core/binning.py
@@ -23,7 +23,7 @@ from __future__ import absolute_import, division
 from collections.abc import Iterable, Mapping, Sequence
 from collections import OrderedDict, namedtuple
 from copy import copy, deepcopy
-from functools import wraps
+from functools import reduce, wraps
 from itertools import chain, product
 from operator import mul
 import re
@@ -37,7 +37,6 @@ from pisa.utils.format import (make_valid_python_name, text2tex,
 from pisa.utils.hash import hash_obj
 from pisa.utils import jsons
 from pisa.utils.log import logging, set_verbosity, tprofile
-from functools import reduce
 
 
 __all__ = ['NAME_FIXES', 'NAME_SEPCHARS', 'NAME_FIXES_REGEXES',
@@ -305,10 +304,12 @@ class OneDimBinning(object):
                             ' %s.' % (be_units, units)
                         )
                     if be_units != units:
-                        logging.warn('`bin_edges` are specified in units of %s'
-                                     ' but `units` is specified as %s.'
-                                     ' Converting `bin_edges` to the latter.',
-                                     be_units, units)
+                        logging.warning(
+                            '`bin_edges` are specified in units of %s'
+                            ' but `units` is specified as %s.'
+                            ' Converting `bin_edges` to the latter.',
+                            be_units, units
+                        )
                         bin_edges.ito(units)
                 dimensionless_bin_edges = bin_edges.magnitude
 
@@ -330,8 +331,11 @@ class OneDimBinning(object):
                             ' %s.' % (domain_units, units)
                         )
                     if domain_units != units:
-                        logging.warn('`domain` units %s will be converted to'
-                                     ' %s.', domain_units, units)
+                        logging.warning(
+                            '`domain` units %s will be converted to' ' %s.',
+                            domain_units,
+                            units,
+                        )
                         domain.ito(units)
                 dimensionless_domain = domain.magnitude
 
@@ -1273,7 +1277,7 @@ class OneDimBinning(object):
         return {'bin_edges': self.bin_edges.to(ureg(str(units)))}
 
     def __getattr__(self, attr):
-        return super(OneDimBinning, self).__getattribute__(attr)
+        return super().__getattribute__(attr)
 
     # TODO: make this actually grab the bins specified (and be able to grab
     # disparate bins, whether or not they are adjacent)... i.e., fill in all
@@ -2685,7 +2689,7 @@ class MultiDimBinning(object):
         except (KeyError, ValueError):
             # If that failed, re-run parent's __getattribute__ which will raise
             # an appropriate exception
-            return super(MultiDimBinning, self).__getattribute__(attr)
+            return super().__getattribute__(attr)
 
     # TODO: refine handling of ellipsis such that the following work as in
     # Numpy:

--- a/pisa/core/distribution_maker.py
+++ b/pisa/core/distribution_maker.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import
 
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 from collections import OrderedDict
+from functools import reduce
 import inspect
 from itertools import product
 import os
@@ -24,7 +25,6 @@ from pisa.utils.fileio import expand, mkdir, to_file
 from pisa.utils.hash import hash_obj
 from pisa.utils.log import set_verbosity, logging
 from pisa.utils.random_numbers import get_random_state
-from functools import reduce
 
 
 __all__ = ['DistributionMaker', 'test_DistributionMaker', 'parse_args', 'main']
@@ -159,10 +159,11 @@ class DistributionMaker(object):
             for pipeline in self:
                 possible_selections = pipeline.param_selections
                 if possible_selections:
-                    logging.warn("Although you didn't make a parameter "
-                                 "selection, the following were available: %s."
-                                 " This may cause issues.",
-                                 possible_selections)
+                    logging.warning(
+                        "Although you didn't make a parameter "
+                        "selection, the following were available: %s."
+                        " This may cause issues.", possible_selections
+                    )
 
     @property
     def pipelines(self):

--- a/pisa/core/events.py
+++ b/pisa/core/events.py
@@ -505,7 +505,7 @@ class Data(FlavIntDataGroup):
         if data == dict():
             self._flavint_groups = []
         else:
-            super(Data, self).__init__(val=data, flavint_groups=flavint_groups)
+            super().__init__(val=data, flavint_groups=flavint_groups)
             self.contains_neutrinos = True
 
         # Check consistency of flavints_joined
@@ -717,7 +717,7 @@ class Data(FlavIntDataGroup):
         -------
         t_data : Data
         """
-        t_fidg = super(Data, self).transform_groups(flavint_groups)
+        t_fidg = super().transform_groups(flavint_groups)
         metadata = deepcopy(self.metadata)
         metadata['flavints_joined'] = [str(f) for f in t_fidg.flavint_groups]
         t_dict = dict(t_fidg)
@@ -986,7 +986,7 @@ class Data(FlavIntDataGroup):
                 return self.muons
             if arg == 'noise':
                 return self.noise
-        tgt_obj = super(Data, self).__getitem__(arg)
+        tgt_obj = super().__getitem__(arg)
         return tgt_obj
 
     def __setitem__(self, arg, value):
@@ -998,7 +998,7 @@ class Data(FlavIntDataGroup):
             if arg == 'noise':
                 self.noise = value
                 return
-        super(Data, self).__setitem__(arg, value)
+        super().__setitem__(arg, value)
 
     def __add__(self, other):
         muons = None
@@ -1058,7 +1058,7 @@ class Data(FlavIntDataGroup):
         elif len(other.flavint_groups) == 0:
             a_fidg = FlavIntDataGroup(self)
         else:
-            a_fidg = super(Data, self).__add__(other)
+            a_fidg = super().__add__(other)
         metadata['flavints_joined'] = [str(f) for f in a_fidg.flavint_groups]
 
         if muons is not None:

--- a/pisa/core/events_pi.py
+++ b/pisa/core/events_pi.py
@@ -91,7 +91,7 @@ class EventsPi(OrderedDict):
         neutrinos = kw.pop("neutrinos", True)
         fraction_events_to_keep = kw.pop("fraction_events_to_keep", None)
 
-        super(EventsPi, self).__init__(*arg, **kw)
+        super().__init__(*arg, **kw)
 
         self.name = name
         self.neutrinos = neutrinos

--- a/pisa/core/map.py
+++ b/pisa/core/map.py
@@ -13,6 +13,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from collections import OrderedDict 
 from copy import deepcopy, copy
 from fnmatch import fnmatch
+from functools import reduce
 from itertools import permutations
 from operator import add, getitem, setitem
 import os
@@ -39,7 +40,6 @@ from pisa.utils.format import (make_valid_python_name, strip_outer_dollars,
 from pisa.utils.log import logging, set_verbosity
 from pisa.utils.random_numbers import get_random_state
 from pisa.utils import stats
-from functools import reduce
 
 
 __all__ = ['type_error', 'reduceToHist', 'rebin', 'valid_nominal_values',
@@ -301,10 +301,10 @@ class Map(object):
     def __init__(self, name, hist, binning, error_hist=None, hash=None,
                  tex=None, full_comparison=False):
         # Set Read/write attributes via their defined setters
-        super(Map, self).__setattr__('_name', name)
-        super(Map, self).__setattr__('_tex', tex)
-        super(Map, self).__setattr__('_hash', hash)
-        super(Map, self).__setattr__('_full_comparison', full_comparison)
+        super().__setattr__('_name', name)
+        super().__setattr__('_tex', tex)
+        super().__setattr__('_hash', hash)
+        super().__setattr__('_full_comparison', full_comparison)
 
         if not isinstance(binning, MultiDimBinning):
             if isinstance(binning, Sequence):
@@ -317,9 +317,9 @@ class Map(object):
         self.parent_indexer = None
 
         # Do the work here to set read-only attributes
-        super(Map, self).__setattr__('_binning', binning)
+        super().__setattr__('_binning', binning)
         binning.assert_array_fits(hist)
-        super(Map, self).__setattr__(
+        super().__setattr__(
             '_hist', np.ascontiguousarray(hist)
         )
         if error_hist is not None:
@@ -464,7 +464,7 @@ class Map(object):
     def set_poisson_errors(self):
         """Approximate poisson errors using sqrt(n)."""
         nom_values = self.nominal_values
-        super(Map, self).__setattr__(
+        super().__setattr__(
             '_hist',
             unp.uarray(nom_values, np.sqrt(nom_values))
         )
@@ -482,12 +482,12 @@ class Map(object):
 
         """
         if error_hist is None:
-            super(Map, self).__setattr__(
+            super().__setattr__(
                 '_hist', self.nominal_values
             )
             return
         self.assert_compat(error_hist)
-        super(Map, self).__setattr__(
+        super().__setattr__(
             '_hist',
             unp.uarray(self._hist, np.ascontiguousarray(error_hist))
         )
@@ -1184,10 +1184,10 @@ class Map(object):
         """Only allow setting attributes defined in slots"""
         if attr not in self._slots:
             raise ValueError('Attribute "%s" not allowed to be set.' % attr)
-        super(Map, self).__setattr__(attr, value)
+        super().__setattr__(attr, value)
 
     def __getattr__(self, attr):
-        return super(Map, self).__getattribute__(attr)
+        return super().__getattribute__(attr)
 
     def _slice_or_index(self, idx):
         """Slice or index into the map. Indexing single element in self.hist
@@ -1542,7 +1542,7 @@ class Map(object):
     def name(self, value):
         """map name"""
         assert isinstance(value, str)
-        return super(Map, self).__setattr__('_name', value)
+        return super().__setattr__('_name', value)
 
     @property
     def tex(self):
@@ -1556,7 +1556,7 @@ class Map(object):
         assert value is None or isinstance(value, str)
         if value is not None:
             value = strip_outer_dollars(value)
-        return super(Map, self).__setattr__('_tex', value)
+        return super().__setattr__('_tex', value)
 
     @property
     def hash(self):
@@ -1567,7 +1567,7 @@ class Map(object):
     def hash(self, value):
         """Hash must be an immutable type (i.e., have a __hash__ method)"""
         assert hasattr(value, '__hash__')
-        super(Map, self).__setattr__('_hash', value)
+        super().__setattr__('_hash', value)
 
     @property
     def hist(self):
@@ -1597,7 +1597,7 @@ class Map(object):
     @full_comparison.setter
     def full_comparison(self, value):
         assert isinstance(value, bool)
-        super(Map, self).__setattr__('_full_comparison', value)
+        super().__setattr__('_full_comparison', value)
 
     # Common mathematical operators
 
@@ -1947,13 +1947,13 @@ class MapSet(object):
             else:
                 maps_.append(Map(**m))
 
-        super(MapSet, self).__setattr__('maps', maps_)
-        super(MapSet, self).__setattr__('name', name)
-        super(MapSet, self).__setattr__('tex', tex)
-        super(MapSet, self).__setattr__(
+        super().__setattr__('maps', maps_)
+        super().__setattr__('name', name)
+        super().__setattr__('tex', tex)
+        super().__setattr__(
             'collate_by_name', collate_by_name
         )
-        super(MapSet, self).__setattr__('collate_by_num', not collate_by_name)
+        super().__setattr__('collate_by_num', not collate_by_name)
         self.hash = hash
 
     def __repr__(self):
@@ -2370,12 +2370,12 @@ class MapSet(object):
     @property
     def name(self):
         """string : name of the map (legal Python name)"""
-        return super(MapSet, self).__getattribute__('_name')
+        return super().__getattribute__('_name')
 
     @name.setter
     def name(self, name):
         """string : name of the map (legal Python name)"""
-        return super(MapSet, self).__setattr__('_name', name)
+        return super().__setattr__('_name', name)
 
     @property
     def hash(self):

--- a/pisa/core/param.py
+++ b/pisa/core/param.py
@@ -711,7 +711,7 @@ class ParamSet(Sequence):
 
     def __getattr__(self, attr):
         try:
-            return super(ParamSet, self).__getattribute__(attr)
+            return super().__getattribute__(attr)
         except AttributeError:
             t, v, tb = sys.exc_info()
             try:
@@ -721,7 +721,7 @@ class ParamSet(Sequence):
 
     def __setattr__(self, attr, val):
         try:
-            params = super(ParamSet, self).__getattribute__('_params')
+            params = super().__getattribute__('_params')
             param_names = [p.name for p in params]
         except AttributeError:
             params = []
@@ -729,7 +729,7 @@ class ParamSet(Sequence):
         try:
             idx = param_names.index(attr)
         except ValueError:
-            super(ParamSet, self).__setattr__(attr, val)
+            super().__setattr__(attr, val)
         else:
             # `attr` (should be) param name
             if isinstance(val, Param):

--- a/pisa/core/pi_stage.py
+++ b/pisa/core/pi_stage.py
@@ -77,7 +77,7 @@ class PiStage(BaseStage):
         input_calc_keys=(),
         output_calc_keys=(),
     ):
-        super(PiStage, self).__init__(
+        super().__init__(
             params=params,
             expected_params=expected_params,
             input_names=input_names,

--- a/pisa/core/pipeline.py
+++ b/pisa/core/pipeline.py
@@ -730,7 +730,7 @@ def main(return_outputs=False):
         # Create dummy inputs if necessary
         inputs = None
         if hasattr(stage, "input_binning"):
-            logging.warn(
+            logging.warning(
                 "Stage requires input, so building dummy"
                 " inputs of random numbers, with random state set to the input"
                 " index according to alphabetical ordering of input names and"

--- a/pisa/core/stage.py
+++ b/pisa/core/stage.py
@@ -159,7 +159,7 @@ class Stage(BaseStage):
         self.validate_binning()
 
         # init base class!
-        super(Stage, self).__init__(
+        super().__init__(
             params=params,
             expected_params=expected_params,
             input_names=input_names,

--- a/pisa/core/transform.py
+++ b/pisa/core/transform.py
@@ -304,7 +304,7 @@ class TransformSet(object):
 
     def __getattr__(self, attr):
         if attr in TRANS_SET_SLOTS:
-            return super(TransformSet, self).__getattribute__(attr)
+            return super().__getattribute__(attr)
         # TODO: return maps based upon name?
         #if attr in
         return TransformSet([getattr(t, attr) for t in self], name=self.name)
@@ -648,7 +648,7 @@ class BinnedTensorTransform(Transform):
     def __init__(self, input_names, output_name, input_binning, output_binning,
                  xform_array, sum_inputs=False, error_array=None, tex=None,
                  error_method=None, hash=None): # pylint: disable=redefined-builtin
-        super(BinnedTensorTransform, self).__init__(
+        super().__init__(
             input_names=input_names, output_name=output_name,
             input_binning=input_binning, output_binning=output_binning,
             tex=tex, hash=hash, error_method=error_method
@@ -662,7 +662,7 @@ class BinnedTensorTransform(Transform):
     @property
     def serializable_state(self):
         """OrderedDict : State of the object in a format that is serializable"""
-        state = super(BinnedTensorTransform, self).serializable_state
+        state = super().serializable_state
         state['xform_array'] = self.nominal_values
         state['error_array'] = self.std_devs
         return state
@@ -670,7 +670,7 @@ class BinnedTensorTransform(Transform):
     @property
     def hashable_state(self):
         """OrderedDict : State of the objec that can be used for hashing"""
-        state = super(BinnedTensorTransform, self).hashable_state
+        state = super().hashable_state
         state['xform_array'] = normQuant(self.nominal_values,
                                          sigfigs=HASH_SIGFIGS)
         state['error_array'] = normQuant(self.std_devs, sigfigs=HASH_SIGFIGS)
@@ -689,12 +689,12 @@ class BinnedTensorTransform(Transform):
 
         """
         if error_array is None:
-            super(BinnedTensorTransform, self).__setattr__(
+            super().__setattr__(
                 '_xform_array', self.nominal_values
             )
             return
         assert error_array.shape == self.xform_array.shape
-        super(BinnedTensorTransform, self).__setattr__(
+        super().__setattr__(
             '_xform_array',
             unp.uarray(self.xform_array, np.ascontiguousarray(error_array))
         )

--- a/pisa/scripts/fit_discrete_sys_nd.py
+++ b/pisa/scripts/fit_discrete_sys_nd.py
@@ -145,11 +145,12 @@ from __future__ import absolute_import, division, print_function
 
 from argparse import ArgumentParser
 from ast import literal_eval
-from collections import Mapping, Sequence, OrderedDict
+from collections import OrderedDict
+from collections.abc import Mapping, Sequence
 import copy
+from io import StringIO
 from os.path import join
 import re
-from StringIO import StringIO
 
 import numpy as np
 from scipy.optimize import curve_fit
@@ -359,7 +360,7 @@ def parse_fit_config(fit_cfg):
             units_list.append(units_spec)
     else:
         units_list = ["dimensionless" for s in sys_list]
-        logging.warn(
+        logging.warning(
             "No %s option found in %s section; assuming systematic parameters are"
             " dimensionless",
             UNITS_OPTION,
@@ -384,7 +385,7 @@ def parse_fit_config(fit_cfg):
         try:
             combine_regex = literal_eval(combine_regex)
         except (SyntaxError, ValueError):
-            logging.warn(
+            logging.warning(
                 'Deprecated syntax for "combine_re" (make into a Python-evaluatable'
                 "sequence of strings instead) :: combine_regex = %s",
                 combine_regex,
@@ -487,7 +488,7 @@ def load_and_modify_pipeline_cfg(fit_cfg, section):
                     )
                     pipeline_cfg.remove_section(section_map[no_ws_section_spec])
             else:
-                logging.warn(
+                logging.warning(
                     "Told to remove section [%s] but section does not exist in"
                     ' pipline config "%s"',
                     section_spec,
@@ -602,7 +603,7 @@ def make_discrete_sys_distributions(fit_cfg, set_params=None):
     nsets = len(sys_sets_info)
     nsys = len(sys_list)
     if nsets <= nsys:
-        logging.warn(
+        logging.warning(
             "Fit will either fail or be unreliable since the number of"
             " systematics sets to be fit is small (%d <= %d).",
             nsets,
@@ -970,7 +971,7 @@ def fit_discrete_sys_distributions(input_data, p0=None, fit_method=None):
 
                     # without error estimates each point has the same weight
                     # and we cannot get chi-square values (but can still fit)
-                    logging.warn(
+                    logging.warning(
                         "No uncertainties for any of the normalised counts in bin"
                         ' %s ("%s") found. Fit is performed unweighted and no'
                         " chisquare values will be available.",

--- a/pisa/scripts/inj_param_scan.py
+++ b/pisa/scripts/inj_param_scan.py
@@ -210,7 +210,7 @@ def inj_param_scan(return_outputs=False):
     if hypo_testing.data_maker.params[test_name].prior is not None:
         if hypo_testing.data_maker.params[test_name].prior.kind != 'uniform':
             if force_prior:
-                logging.warn(
+                logging.warning(
                     'Parameter to be scanned, %s, has a %s prior that you have'
                     ' requested to be left on. This will likely make the'
                     ' results wrong.',

--- a/pisa/scripts/make_asymmetry_plots.py
+++ b/pisa/scripts/make_asymmetry_plots.py
@@ -391,7 +391,7 @@ def main():
                     " in order to make the asymmetry plots"
                 )
             if pid_names is None:
-                logging.warn(
+                logging.warning(
                     "There are no names given for the PID bins, thus "
                     "they will just be numbered in both the the plot "
                     "save names and titles."

--- a/pisa/scripts/make_events_file.py
+++ b/pisa/scripts/make_events_file.py
@@ -366,7 +366,7 @@ def makeEventsFile(data_files, detector, proc_ver, cut, outdir,
                     fname, run_settings=run_settings
                 )
             except (ValueError, KeyError, IOError):
-                logging.warn('Bad file encountered: %s', fname)
+                logging.warning('Bad file encountered: %s', fname)
                 bad_files.append(fname)
                 continue
 
@@ -488,9 +488,11 @@ def makeEventsFile(data_files, detector, proc_ver, cut, outdir,
         logging.info('Files read, run %s: %d', run, count)
         ref_num_i3_files = run_settings[run]['num_i3_files']
         if count != ref_num_i3_files:
-            logging.warn('Run %s, Number of files read (%d) != number of '
-                         'source I3 files (%d), which may indicate an error.',
-                         run, count, ref_num_i3_files)
+            logging.warning(
+                'Run %s, Number of files read (%d) != number of '
+                'source I3 files (%d), which may indicate an error.',
+                run, count, ref_num_i3_files
+            )
 
     # Generate output data
     for flavint in ALL_NUFLAVINTS:

--- a/pisa/scripts/make_systematic_variation_plots.py
+++ b/pisa/scripts/make_systematic_variation_plots.py
@@ -278,9 +278,11 @@ def main():
 
         pid_names = baseline_map.binning['pid'].bin_names
         if pid_names is None:
-            logging.warn('There are no names given for the PID bins, thus '
-                         'they will just be numbered in both the the plot '
-                         'save names and titles.')
+            logging.warning(
+                'There are no names given for the PID bins, thus '
+                'they will just be numbered in both the the plot '
+                'save names and titles.'
+            )
             pid_names = [x for x in range(
                 0, baseline_map.binning['pid'].num_bins)]
 

--- a/pisa/scripts/make_toy_events.py
+++ b/pisa/scripts/make_toy_events.py
@@ -659,7 +659,7 @@ def make_toy_events(outdir, num_events, energy_range, spectral_index,
         )
         mcevts_fpath = os.path.join(outdir, mcevts_fname)
         if os.path.isfile(mcevts_fpath):
-            logging.warn('File already exists, skipping: "%s"', mcevts_fpath)
+            logging.warning('File already exists, skipping: "%s"', mcevts_fpath)
             continue
 
         logging.info('Working on set "%s"', mcevts_fname)

--- a/pisa/scripts/test_flux_weights.py
+++ b/pisa/scripts/test_flux_weights.py
@@ -1545,8 +1545,10 @@ def main():
                 title_filename += ' Sudbury'
                 legend_filename += ' SNO'
             else:
-                logging.warn('Don\'t know what to do with site %s.'
-                             'Omitting from titles', site)
+                logging.warning(
+                    'Don\'t know what to do with site %s.'
+                    'Omitting from titles', site
+                )
 
             title_filename += ' %s'%year
             legend_filename += ' %s'%year
@@ -1617,8 +1619,10 @@ def main():
             title_filename += ' Sudbury'
             legend_filename += ' SNO'
         else:
-            logging.warn('Don\'t know what to do with site %s.'
-                         'Omitting from titles', site)
+            logging.warning(
+                'Don\'t know what to do with site %s.'
+                'Omitting from titles', site
+            )
 
         title_filename += ' %s'%year
         legend_filename += ' %s'%year

--- a/pisa/stages/absorption/pi_earth_absorption.py
+++ b/pisa/stages/absorption/pi_earth_absorption.py
@@ -83,19 +83,20 @@ class pi_earth_absorption(PiStage):
                             )
 
         # init base class
-        super(pi_earth_absorption, self).__init__(data=data,
-                                                  params=params,
-                                                  expected_params=expected_params,
-                                                  input_names=input_names,
-                                                  output_names=output_names,
-                                                  debug_mode=debug_mode,
-                                                  input_specs=input_specs,
-                                                  calc_specs=calc_specs,
-                                                  output_specs=output_specs,
-                                                  input_apply_keys=input_apply_keys,
-                                                  output_calc_keys=output_calc_keys,
-                                                  output_apply_keys=output_apply_keys,
-                                                 )
+        super().__init__(
+            data=data,
+            params=params,
+            expected_params=expected_params,
+            input_names=input_names,
+            output_names=output_names,
+            debug_mode=debug_mode,
+            input_specs=input_specs,
+            calc_specs=calc_specs,
+            output_specs=output_specs,
+            input_apply_keys=input_apply_keys,
+            output_calc_keys=output_calc_keys,
+            output_apply_keys=output_apply_keys,
+        )
 
         assert self.input_mode is not None
         assert self.calc_mode is not None

--- a/pisa/stages/aeff/hist.py
+++ b/pisa/stages/aeff/hist.py
@@ -342,7 +342,7 @@ class hist(Stage):
 
         # Invoke the init method from the parent class, which does a lot of
         # work for you.
-        super(self.__class__, self).__init__(
+        super().__init__(
             use_transforms=True,
             params=params,
             expected_params=expected_params,

--- a/pisa/stages/aeff/param.py
+++ b/pisa/stages/aeff/param.py
@@ -256,7 +256,7 @@ class param(Stage):
         logging.trace('transform_groups = %s', self.transform_groups)
         logging.trace('output_names = %s', ' :: '.join(output_names))
 
-        super(self.__class__, self).__init__(
+        super().__init__(
             use_transforms=True,
             params=params,
             expected_params=expected_params,

--- a/pisa/stages/aeff/pi_aeff.py
+++ b/pisa/stages/aeff/pi_aeff.py
@@ -62,18 +62,19 @@ class pi_aeff(PiStage):
                             )
 
         # init base class
-        super(pi_aeff, self).__init__(data=data,
-                                      params=params,
-                                      expected_params=expected_params,
-                                      input_names=input_names,
-                                      output_names=output_names,
-                                      debug_mode=debug_mode,
-                                      input_specs=input_specs,
-                                      calc_specs=calc_specs,
-                                      output_specs=output_specs,
-                                      input_apply_keys=input_apply_keys,
-                                      output_apply_keys=output_apply_keys,
-                                     )
+        super().__init__(
+            data=data,
+            params=params,
+            expected_params=expected_params,
+            input_names=input_names,
+            output_names=output_names,
+            debug_mode=debug_mode,
+            input_specs=input_specs,
+            calc_specs=calc_specs,
+            output_specs=output_specs,
+            input_apply_keys=input_apply_keys,
+            output_apply_keys=output_apply_keys,
+        )
 
         assert self.input_mode is not None
         assert self.calc_mode is None

--- a/pisa/stages/aeff/pi_weight.py
+++ b/pisa/stages/aeff/pi_weight.py
@@ -50,18 +50,19 @@ class pi_weight(PiStage):
                             )
 
         # init base class
-        super(pi_weight, self).__init__(data=data,
-                                      params=params,
-                                      expected_params=expected_params,
-                                      input_names=input_names,
-                                      output_names=output_names,
-                                      debug_mode=debug_mode,
-                                      input_specs=input_specs,
-                                      calc_specs=calc_specs,
-                                      output_specs=output_specs,
-                                      input_apply_keys=input_apply_keys,
-                                      output_apply_keys=output_apply_keys,
-                                     )
+        super().__init__(
+            data=data,
+            params=params,
+            expected_params=expected_params,
+            input_names=input_names,
+            output_names=output_names,
+            debug_mode=debug_mode,
+            input_specs=input_specs,
+            calc_specs=calc_specs,
+            output_specs=output_specs,
+            input_apply_keys=input_apply_keys,
+            output_apply_keys=output_apply_keys,
+        )
 
         assert self.input_mode is not None
         assert self.calc_mode is None

--- a/pisa/stages/aeff/smooth.py
+++ b/pisa/stages/aeff/smooth.py
@@ -155,7 +155,7 @@ class smooth(Stage):
 
         # Invoke the init method from the parent class, which does a lot of
         # work for you.
-        super(self.__class__, self).__init__(
+        super().__init__(
             use_transforms=True,
             params=params,
             expected_params=expected_params,

--- a/pisa/stages/background/atm_muons.py
+++ b/pisa/stages/background/atm_muons.py
@@ -85,17 +85,18 @@ class atm_muons(PiStage):
                             )
 
         # init base class
-        super(atm_muons, self).__init__(data=data,
-                                        params=params,
-                                        expected_params=expected_params,
-                                        input_names=input_names,
-                                        output_names=output_names,
-                                        debug_mode=debug_mode,
-                                        input_specs=input_specs,
-                                        calc_specs=calc_specs,
-                                        output_specs=output_specs,
-                                        output_apply_keys=output_apply_keys,
-                                       )
+        super().__init__(
+            data=data,
+            params=params,
+            expected_params=expected_params,
+            input_names=input_names,
+            output_names=output_names,
+            debug_mode=debug_mode,
+            input_specs=input_specs,
+            calc_specs=calc_specs,
+            output_specs=output_specs,
+            output_apply_keys=output_apply_keys,
+        )
 
         assert self.input_mode is not None
         assert self.calc_mode is not None

--- a/pisa/stages/combine/nutau.py
+++ b/pisa/stages/combine/nutau.py
@@ -65,7 +65,7 @@ class nutau(Stage):
             self.combine_groups[key] = split(val, sep=',')
         output_names = self.combine_groups.keys()
 
-        super(self.__class__, self).__init__(
+        super().__init__(
             use_transforms=True,
             params=params,
             expected_params=expected_params,

--- a/pisa/stages/data/csv_data_hist.py
+++ b/pisa/stages/data/csv_data_hist.py
@@ -48,7 +48,7 @@ class csv_data_hist(PiStage):
             'weights',
         )
         # init base class
-        super(csv_data_hist, self).__init__(
+        super().__init__(
             data=data,
             params=params,
             expected_params=expected_params,

--- a/pisa/stages/data/csv_icc_hist.py
+++ b/pisa/stages/data/csv_icc_hist.py
@@ -50,7 +50,7 @@ class csv_icc_hist(PiStage):
             'weights',
         )
         # init base class
-        super(csv_icc_hist, self).__init__(
+        super().__init__(
             data=data,
             params=params,
             expected_params=expected_params,

--- a/pisa/stages/data/csv_loader.py
+++ b/pisa/stages/data/csv_loader.py
@@ -49,7 +49,7 @@ class csv_loader(PiStage):
             'weights',
         )
         # init base class
-        super(csv_loader, self).__init__(
+        super().__init__(
             data=data,
             params=params,
             expected_params=expected_params,

--- a/pisa/stages/data/data.py
+++ b/pisa/stages/data/data.py
@@ -64,7 +64,7 @@ class data(Stage):
 
         output_names = ('total')
 
-        super(self.__class__, self).__init__(
+        super().__init__(
             use_transforms=False,
             params=params,
             expected_params=expected_params,

--- a/pisa/stages/data/events_to_data.py
+++ b/pisa/stages/data/events_to_data.py
@@ -7,23 +7,16 @@ The outputs should be consistent with the 'sample' stage
 
 from __future__ import absolute_import
 
-from os import path
 from copy import deepcopy
+from functools import reduce
 from operator import add
-import re
 
-import numpy as np
-
-from pisa import ureg
 from pisa.core.events import Data, Events
-from pisa.core.map import MapSet
 from pisa.core.stage import Stage
-from pisa.utils.fileio import from_file
 from pisa.utils.flavInt import ALL_NUFLAVINTS, NuFlavIntGroup, FlavIntDataGroup
 from pisa.utils.hash import hash_obj
 from pisa.utils.log import logging
 from pisa.utils.profiler import profile
-from functools import reduce
 
 
 __all__ = ['SEP', 'events_to_data']
@@ -129,7 +122,7 @@ class events_to_data(Stage):
             output_binning = None
         self.output_events = output_events
 
-        super(events_to_data, self).__init__(
+        super().__init__(
             use_transforms=False,
             params=params,
             expected_params=expected_params,
@@ -140,7 +133,7 @@ class events_to_data(Stage):
             memcache_deepcopy=memcache_deepcopy,
             outputs_cache_depth=outputs_cache_depth,
             transforms_cache_depth=transforms_cache_depth,
-            output_binning=output_binning
+            output_binning=output_binning,
         )
 
         self._compute_outputs()

--- a/pisa/stages/data/icc.py
+++ b/pisa/stages/data/icc.py
@@ -79,7 +79,7 @@ class icc(Stage):
 
         output_names = ('total')
 
-        super(self.__class__, self).__init__(
+        super().__init__(
             use_transforms=False,
             params=params,
             expected_params=expected_params,

--- a/pisa/stages/data/sample.py
+++ b/pisa/stages/data/sample.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import
 
 from os import path
 from copy import deepcopy
+from functools import reduce
 from operator import add
 import re
 
@@ -28,7 +29,6 @@ from pisa.utils.flavInt import ALL_NUFLAVINTS, NuFlavIntGroup, FlavIntDataGroup
 from pisa.utils.hash import hash_obj
 from pisa.utils.log import logging
 from pisa.utils.profiler import profile
-from functools import reduce
 
 
 __all__ = ['SEP', 'sample','split','parse_event_type_names']
@@ -64,7 +64,7 @@ def split(string):
 def parse_event_type_names(names,return_flags=False) :
 
     #Split into list if has not already been done
-    if isinstance(names,str) or isinstance(names,unicode) :
+    if isinstance(names, str):
         names = split(names)
 
     #Parse the names
@@ -165,7 +165,7 @@ class sample(Stage):
             output_binning = None
         self.output_events = output_events
 
-        super(sample, self).__init__(
+        super().__init__(
             use_transforms=False,
             params=params,
             expected_params=expected_params,
@@ -176,7 +176,7 @@ class sample(Stage):
             memcache_deepcopy=memcache_deepcopy,
             outputs_cache_depth=outputs_cache_depth,
             transforms_cache_depth=transforms_cache_depth,
-            output_binning=output_binning
+            output_binning=output_binning,
         )
 
         #User can specify that truth variables have their names prefixed with "truth_"

--- a/pisa/stages/data/simple_data_loader.py
+++ b/pisa/stages/data/simple_data_loader.py
@@ -88,7 +88,7 @@ class simple_data_loader(PiStage):
             'weights',
         )
         # init base class
-        super(simple_data_loader, self).__init__(
+        super().__init__(
             data=data,
             params=params,
             expected_params=expected_params,

--- a/pisa/stages/data/toy_event_generator.py
+++ b/pisa/stages/data/toy_event_generator.py
@@ -53,17 +53,18 @@ class toy_event_generator(PiStage):
                            )
 
         # init base class
-        super(toy_event_generator, self).__init__(data=data,
-                                                  params=params,
-                                                  expected_params=expected_params,
-                                                  input_names=input_names,
-                                                  output_names=output_names,
-                                                  debug_mode=debug_mode,
-                                                  input_specs=input_specs,
-                                                  calc_specs=calc_specs,
-                                                  output_specs=output_specs,
-                                                  input_apply_keys=input_apply_keys,
-                                                 )
+        super().__init__(
+            data=data,
+            params=params,
+            expected_params=expected_params,
+            input_names=input_names,
+            output_names=output_names,
+            debug_mode=debug_mode,
+            input_specs=input_specs,
+            calc_specs=calc_specs,
+            output_specs=output_specs,
+            input_apply_keys=input_apply_keys,
+        )
 
         # doesn't calculate anything
         assert self.calc_mode is None

--- a/pisa/stages/discr_sys/fit.py
+++ b/pisa/stages/discr_sys/fit.py
@@ -212,7 +212,7 @@ class fit(Stage):
             output_binning = None
         self.output_events = output_events
 
-        super(self.__class__, self).__init__(
+        super().__init__(
             use_transforms=False,
             params=params,
             expected_params=expected_params,

--- a/pisa/stages/discr_sys/hyperplane.py
+++ b/pisa/stages/discr_sys/hyperplane.py
@@ -59,7 +59,7 @@ class hyperplane(Stage):
 
         # Invoke the init method from the parent class, which does a lot of
         # work for you.
-        super(self.__class__, self).__init__(
+        super().__init__(
             use_transforms=True,
             params=params,
             expected_params=expected_params,
@@ -70,7 +70,7 @@ class hyperplane(Stage):
             error_method=error_method,
             transforms_cache_depth=transforms_cache_depth,
             input_binning=input_binning,
-            output_binning=output_binning
+            output_binning=output_binning,
         )
         self.fit_results = None
         self.sys_list = None

--- a/pisa/stages/discr_sys/pi_hyperplanes.py
+++ b/pisa/stages/discr_sys/pi_hyperplanes.py
@@ -188,7 +188,7 @@ class pi_hyperplanes(PiStage):  # pyint: disable=invalid-name
             fit_binning_hash = fit_results.get("binning_hash", None)
 
         if fit_binning_hash is None:
-            logging.warn(
+            logging.warning(
                 "Cannot determine the hash of the binning employed"
                 " for the hyperplane fits. Correct application of"
                 " fits is not guaranteed!"
@@ -213,7 +213,7 @@ class pi_hyperplanes(PiStage):  # pyint: disable=invalid-name
 
         # -- Initialize base class -- #
 
-        super(pi_hyperplanes, self).__init__(
+        super().__init__(
             data=data,
             params=params,
             expected_params=fit_param_names,

--- a/pisa/stages/discr_sys/polyfits.py
+++ b/pisa/stages/discr_sys/polyfits.py
@@ -60,7 +60,7 @@ class polyfits(Stage):
 
         # Invoke the init method from the parent class, which does a lot of
         # work for you.
-        super(self.__class__, self).__init__(
+        super().__init__(
             use_transforms=True,
             params=params,
             expected_params=expected_params,

--- a/pisa/stages/flux/dummy.py
+++ b/pisa/stages/flux/dummy.py
@@ -55,7 +55,7 @@ class dummy(Stage): # pylint: disable=invalid-name
         # there are no "inputs" used by this stage. (Of course there are
         # parameters, and files with info, but no maps or MC events are used
         # and transformed directly by this stage to produce its output.)
-        super(dummy, self).__init__(
+        super().__init__(
             use_transforms=False,
             params=params,
             expected_params=expected_params,
@@ -65,7 +65,7 @@ class dummy(Stage): # pylint: disable=invalid-name
             memcache_deepcopy=memcache_deepcopy,
             outputs_cache_depth=outputs_cache_depth,
             output_binning=output_binning,
-            debug_mode=debug_mode
+            debug_mode=debug_mode,
         )
 
         # There might be other things to do at init time than what Stage does,

--- a/pisa/stages/flux/honda.py
+++ b/pisa/stages/flux/honda.py
@@ -351,7 +351,7 @@ class honda(Stage): #pylint: disable=invalid-name
         # there are no "inputs" used by this stage. (Of course there are
         # parameters, and files with info, but no maps or MC events are used
         # and transformed directly by this stage to produce its output.)
-        super(honda, self).__init__(
+        super().__init__(
             use_transforms=False,
             params=params,
             expected_params=expected_params,
@@ -361,7 +361,7 @@ class honda(Stage): #pylint: disable=invalid-name
             memcache_deepcopy=memcache_deepcopy,
             outputs_cache_depth=outputs_cache_depth,
             output_binning=output_binning,
-            debug_mode=debug_mode
+            debug_mode=debug_mode,
         )
 
         # Set the neutrio primaries
@@ -375,17 +375,17 @@ class honda(Stage): #pylint: disable=invalid-name
         if set(output_binning.names) == set(['true_energy', 'true_coszen',
                                              'true_azimuth']):
             self.load_3d_table(smooth=0.05)
-            logging.warn('!! ############################################ !!')
-            logging.warn('')
-            logging.warn('You have requested a full 3D calculation from the '
-                         'tables.')
-            logging.warn('Please be aware that this version is '
-                         'currently untested and so you should put your '
-                         'results under extra scrutiny.')
-            logging.warn('Please also keep in contact with the developers '
-                         'about your findings!')
-            logging.warn('')
-            logging.warn('!! ############################################ !!')
+            logging.warning('!! ############################################ !!')
+            logging.warning('')
+            logging.warning('You have requested a full 3D calculation from the '
+                            'tables.')
+            logging.warning('Please be aware that this version is '
+                            'currently untested and so you should put your '
+                            'results under extra scrutiny.')
+            logging.warning('Please also keep in contact with the developers '
+                            'about your findings!')
+            logging.warning('')
+            logging.warning('!! ############################################ !!')
         elif set(self.output_binning.names) == set(['true_energy',
                                                     'true_coszen']):
             self.load_2d_table(smooth=0.05)

--- a/pisa/stages/flux/mceq.py
+++ b/pisa/stages/flux/mceq.py
@@ -146,7 +146,7 @@ class mceq(Stage): # pylint: disable=invalid-name
             'nue', 'numu', 'nuebar', 'numubar'
         )
 
-        super(mceq, self).__init__(
+        super().__init__(
             use_transforms=False,
             params=params,
             expected_params=expected_params,
@@ -156,7 +156,7 @@ class mceq(Stage): # pylint: disable=invalid-name
             disk_cache=disk_cache,
             memcache_deepcopy=memcache_deepcopy,
             outputs_cache_depth=outputs_cache_depth,
-            output_binning=output_binning
+            output_binning=output_binning,
         )
 
     @profile

--- a/pisa/stages/flux/pi_honda_ip.py
+++ b/pisa/stages/flux/pi_honda_ip.py
@@ -62,19 +62,20 @@ class pi_honda_ip(PiStage):
                             )
 
         # init base class
-        super(pi_honda_ip, self).__init__(data=data,
-                                        params=params,
-                                        expected_params=expected_params,
-                                        input_names=input_names,
-                                        output_names=output_names,
-                                        debug_mode=debug_mode,
-                                        input_specs=input_specs,
-                                        calc_specs=calc_specs,
-                                        output_specs=output_specs,
-                                        input_calc_keys=input_calc_keys,
-                                        output_calc_keys=output_calc_keys,
-                                        output_apply_keys=output_apply_keys,
-                                       )
+        super().__init__(
+            data=data,
+            params=params,
+            expected_params=expected_params,
+            input_names=input_names,
+            output_names=output_names,
+            debug_mode=debug_mode,
+            input_specs=input_specs,
+            calc_specs=calc_specs,
+            output_specs=output_specs,
+            input_calc_keys=input_calc_keys,
+            output_calc_keys=output_calc_keys,
+            output_apply_keys=output_apply_keys,
+        )
 
         assert self.input_mode is None
         assert self.calc_mode is not None

--- a/pisa/stages/flux/pi_mceq_barr.py
+++ b/pisa/stages/flux/pi_mceq_barr.py
@@ -86,19 +86,20 @@ class pi_mceq_barr(PiStage):
                             )
 
         # init base class
-        super(pi_mceq_barr, self).__init__(data=data,
-                                        params=params,
-                                        expected_params=expected_params,
-                                        input_names=input_names,
-                                        output_names=output_names,
-                                        debug_mode=debug_mode,
-                                        input_specs=input_specs,
-                                        calc_specs=calc_specs,
-                                        output_specs=output_specs,
-                                        input_calc_keys=input_calc_keys,
-                                        output_calc_keys=output_calc_keys,
-                                        output_apply_keys=output_apply_keys,
-                                       )
+        super().__init__(
+            data=data,
+            params=params,
+            expected_params=expected_params,
+            input_names=input_names,
+            output_names=output_names,
+            debug_mode=debug_mode,
+            input_specs=input_specs,
+            calc_specs=calc_specs,
+            output_specs=output_specs,
+            input_calc_keys=input_calc_keys,
+            output_calc_keys=output_calc_keys,
+            output_apply_keys=output_apply_keys,
+        )
 
         assert self.input_mode is not None
         assert self.calc_mode is not None

--- a/pisa/stages/flux/pi_simple.py
+++ b/pisa/stages/flux/pi_simple.py
@@ -80,7 +80,7 @@ class pi_simple(PiStage):  # pylint: disable=invalid-name
         output_apply_keys = ("sys_flux",)
 
         # init base class
-        super(pi_simple, self).__init__(
+        super().__init__(
             data=data,
             params=params,
             expected_params=expected_params,

--- a/pisa/stages/osc/cake_nusquids.py
+++ b/pisa/stages/osc/cake_nusquids.py
@@ -128,7 +128,7 @@ class cake_nusquids(Stage):
         if input_binning != output_binning:
             raise AssertionError('Input binning must match output binning.')
 
-        super(cake_nusquids, self).__init__(
+        super().__init__(
             use_transforms=False,
             params=params,
             expected_params=expected_params,
@@ -140,7 +140,7 @@ class cake_nusquids(Stage):
             memcache_deepcopy=memcache_deepcopy,
             outputs_cache_depth=outputs_cache_depth,
             input_binning=input_binning,
-            output_binning=output_binning
+            output_binning=output_binning,
         )
 
     @profile

--- a/pisa/stages/osc/decoherence.py
+++ b/pisa/stages/osc/decoherence.py
@@ -41,7 +41,7 @@ class DecoherenceParams(OscParams) : #TODO Start using pi_osc_params instead...
     def __init__(self, deltam21, deltam31, theta12, theta13, theta23, deltacp, gamma21, gamma31, gamma32):
 
         # Call base class constructor
-        super(DecoherenceParams, self).__init__()
+        super().__init__()
 
         # Store args
         # Note that keeping them as quantities here

--- a/pisa/stages/osc/dummy.py
+++ b/pisa/stages/osc/dummy.py
@@ -110,7 +110,7 @@ class dummy(Stage): # pylint: disable=invalid-name
 
         # Invoke the init method from the parent class, which does a lot of
         # work for you.
-        super(dummy, self).__init__(
+        super().__init__(
             use_transforms=True,
             params=params,
             expected_params=expected_params,
@@ -123,7 +123,7 @@ class dummy(Stage): # pylint: disable=invalid-name
             transforms_cache_depth=transforms_cache_depth,
             input_binning=input_binning,
             output_binning=output_binning,
-            debug_mode=debug_mode
+            debug_mode=debug_mode,
         )
 
         # There might be other things to do at init time than what Stage does,
@@ -174,7 +174,7 @@ class dummy(Stage): # pylint: disable=invalid-name
 
         # Illustrate how to find input binning dimensions which the transforms
         # created by this service will not depend on.
-        self.extra_dim_nums = range(self.input_binning.num_dims)
+        self.extra_dim_nums = list(range(self.input_binning.num_dims))
         [self.extra_dim_nums.remove(d) for d in (self.e_dim_num,
                                                  self.cz_dim_num)]
 

--- a/pisa/stages/osc/layers.py
+++ b/pisa/stages/osc/layers.py
@@ -398,7 +398,7 @@ def test_Layers():
     logging.info('Test layers calculation:')
     layer = Layers('osc/PREM_4layer.dat')
     layer.setElecFrac(0.4656, 0.4656, 0.4957)
-    cz = np.linspace(-1, 1, 1e5, dtype=FTYPE)
+    cz = np.linspace(-1, 1, int(1e5), dtype=FTYPE)
     layer.calcLayers(cz)
     logging.info('n_layers = %s' %layer.n_layers)
     logging.info('density  = %s' %layer.density)

--- a/pisa/stages/osc/pi_globes.py
+++ b/pisa/stages/osc/pi_globes.py
@@ -94,19 +94,20 @@ class pi_globes(PiStage):
                       )
 
         # init base class
-        super(pi_globes, self).__init__(data=data,
-                                        params=params,
-                                        expected_params=expected_params,
-                                        input_names=input_names,
-                                        output_names=output_names,
-                                        debug_mode=debug_mode,
-                                        input_specs=input_specs,
-                                        calc_specs=calc_specs,
-                                        output_specs=output_specs,
-                                        input_apply_keys=input_apply_keys,
-                                        output_calc_keys=output_calc_keys,
-                                        output_apply_keys=output_apply_keys,
-                                       )
+        super().__init__(
+            data=data,
+            params=params,
+            expected_params=expected_params,
+            input_names=input_names,
+            output_names=output_names,
+            debug_mode=debug_mode,
+            input_specs=input_specs,
+            calc_specs=calc_specs,
+            output_specs=output_specs,
+            input_apply_keys=input_apply_keys,
+            output_calc_keys=output_calc_keys,
+            output_apply_keys=output_apply_keys,
+        )
 
         assert self.input_mode is not None
         assert self.calc_mode is not None

--- a/pisa/stages/osc/pi_nusquids.py
+++ b/pisa/stages/osc/pi_nusquids.py
@@ -181,19 +181,20 @@ class pi_nusquids(PiStage):
                       )
 
         # init base class
-        super(pi_nusquids, self).__init__(data=data,
-                                       params=params,
-                                       expected_params=expected_params,
-                                       input_names=input_names,
-                                       output_names=output_names,
-                                       debug_mode=debug_mode,
-                                       input_specs=input_specs,
-                                       calc_specs=calc_specs,
-                                       output_specs=output_specs,
-                                       input_apply_keys=input_apply_keys,
-                                       output_calc_keys=output_calc_keys,
-                                       output_apply_keys=output_apply_keys,
-                                      )
+        super().__init__(
+            data=data,
+            params=params,
+            expected_params=expected_params,
+            input_names=input_names,
+            output_names=output_names,
+            debug_mode=debug_mode,
+            input_specs=input_specs,
+            calc_specs=calc_specs,
+            output_specs=output_specs,
+            input_apply_keys=input_apply_keys,
+            output_calc_keys=output_calc_keys,
+            output_apply_keys=output_apply_keys,
+        )
 
         assert self.num_neutrinos == 3, "Only 3-flavor oscillations implemented right now" # TODO Add interface to nuSQuIDS 3+N handling
         assert self.use_nsi == False, "NSI support not yet implemented" # TODO

--- a/pisa/stages/osc/pi_prob3.py
+++ b/pisa/stages/osc/pi_prob3.py
@@ -87,19 +87,20 @@ class pi_prob3(PiStage):
                       )
 
         # init base class
-        super(pi_prob3, self).__init__(data=data,
-                                       params=params,
-                                       expected_params=expected_params,
-                                       input_names=input_names,
-                                       output_names=output_names,
-                                       debug_mode=debug_mode,
-                                       input_specs=input_specs,
-                                       calc_specs=calc_specs,
-                                       output_specs=output_specs,
-                                       input_apply_keys=input_apply_keys,
-                                       output_calc_keys=output_calc_keys,
-                                       output_apply_keys=output_apply_keys,
-                                      )
+        super().__init__(
+            data=data,
+            params=params,
+            expected_params=expected_params,
+            input_names=input_names,
+            output_names=output_names,
+            debug_mode=debug_mode,
+            input_specs=input_specs,
+            calc_specs=calc_specs,
+            output_specs=output_specs,
+            input_apply_keys=input_apply_keys,
+            output_calc_keys=output_calc_keys,
+            output_apply_keys=output_apply_keys,
+        )
 
         assert self.input_mode is not None
         assert self.calc_mode is not None

--- a/pisa/stages/pid/hist.py
+++ b/pisa/stages/pid/hist.py
@@ -237,7 +237,7 @@ class hist(Stage):
         output_names = [self.suffix_channel(in_name, out_chan) for in_name,
                         out_chan in product(input_names, self.output_channels)]
 
-        super(hist, self).__init__(
+        super().__init__(
             use_transforms=True,
             params=params,
             expected_params=expected_params,
@@ -249,7 +249,7 @@ class hist(Stage):
             memcache_deepcopy=memcache_deepcopy,
             input_binning=input_binning,
             output_binning=output_binning,
-            debug_mode=debug_mode
+            debug_mode=debug_mode,
         )
 
         # Can do these now that binning has been set up in call to Stage's init
@@ -344,7 +344,7 @@ class hist(Stage):
 
                 num_invalid = np.sum(~np.isfinite(xform_array))
                 if num_invalid > 0:
-                    logging.warn(
+                    logging.warning(
                         'Group "%s", PID signature "%s" has %d bins with no'
                         ' events (and hence the ability to separate events'
                         ' by PID cannot be ascertained). These are being'

--- a/pisa/stages/pid/param.py
+++ b/pisa/stages/pid/param.py
@@ -230,7 +230,7 @@ class param(Stage):
         elif self.particles == 'muons':
             raise NotImplementedError('%s not implemented.' % self.particles)
 
-        super(self.__class__, self).__init__(
+        super().__init__(
             use_transforms=True,
             params=params,
             expected_params=expected_params,
@@ -254,7 +254,7 @@ class param(Stage):
 
         # If no bin names are present, use the integer bin indices instead
         if self.signatures is None:
-            self.signatures = range(len(output_binning.pid))
+            self.signatures = list(range(len(output_binning.pid)))
 
         # Define the transform binnning...
 

--- a/pisa/stages/pid/pi_shift_scale_pid.py
+++ b/pisa/stages/pid/pi_shift_scale_pid.py
@@ -62,19 +62,20 @@ class pi_shift_scale_pid(PiStage):
         output_apply_keys = ('pid',)
 
         # init base class
-        super(pi_shift_scale_pid, self).__init__(data=data,
-                                                 params=params,
-                                                 expected_params=expected_params,
-                                                 input_names=input_names,
-                                                 output_names=output_names,
-                                                 debug_mode=debug_mode,
-                                                 input_specs=input_specs,
-                                                 calc_specs=calc_specs,
-                                                 output_specs=output_specs,
-                                                 input_apply_keys=input_apply_keys,
-                                                 output_apply_keys=output_apply_keys,
-                                                 output_calc_keys=output_calc_keys,
-                                                 )
+        super().__init__(
+            data=data,
+            params=params,
+            expected_params=expected_params,
+            input_names=input_names,
+            output_names=output_names,
+            debug_mode=debug_mode,
+            input_specs=input_specs,
+            calc_specs=calc_specs,
+            output_specs=output_specs,
+            input_apply_keys=input_apply_keys,
+            output_apply_keys=output_apply_keys,
+            output_calc_keys=output_calc_keys,
+        )
 
         assert self.input_mode is not None
         assert self.calc_mode == 'events'

--- a/pisa/stages/pid/smooth.py
+++ b/pisa/stages/pid/smooth.py
@@ -224,7 +224,7 @@ class smooth(Stage):
         output_names = [self.suffix_channel(in_name, out_chan) for in_name,
                         out_chan in product(input_names, self.output_channels)]
 
-        super(self.__class__, self).__init__(
+        super().__init__(
             use_transforms=True,
             params=params,
             expected_params=expected_params,
@@ -236,7 +236,7 @@ class smooth(Stage):
             memcache_deepcopy=memcache_deepcopy,
             input_binning=input_binning,
             output_binning=output_binning,
-            debug_mode=debug_mode
+            debug_mode=debug_mode,
         )
 
         # Can do these now that binning has been set up in call to Stage's init
@@ -331,7 +331,7 @@ class smooth(Stage):
 
                 num_invalid = np.sum(~np.isfinite(xform_array))
                 if num_invalid > 0:
-                    logging.warn(
+                    logging.warning(
                         'Group "%s", PID signature "%s" has %d bins with no'
                         ' events (and hence the ability to separate events'
                         ' by PID cannot be ascertained). These are being'

--- a/pisa/stages/reco/hist.py
+++ b/pisa/stages/reco/hist.py
@@ -160,7 +160,7 @@ class hist(Stage):
 
         # Invoke the init method from the parent class, which does a lot of
         # work for you.
-        super(self.__class__, self).__init__(
+        super().__init__(
             use_transforms=True,
             params=params,
             expected_params=expected_params,

--- a/pisa/stages/reco/param.py
+++ b/pisa/stages/reco/param.py
@@ -7,8 +7,8 @@ transforms.
 
 from __future__ import division
 
-from collections.abc import Mapping
 from collections import OrderedDict
+from collections.abc import Mapping
 from copy import deepcopy
 import itertools
 
@@ -160,8 +160,9 @@ def load_reco_param(source):
 
                 for k in dist_dict.keys():
                     if k not in required_keys:
-                        logging.warn("Unrecognised key in distribution"
-                                     " property dict: '%s'"%k)
+                        logging.warning(
+                            "Unrecognised key in distribution property dict: '%s'"%k
+                        )
 
                 dist_spec = dist_dict['dist']
 
@@ -494,7 +495,7 @@ class param(Stage):
 
         # Invoke the init method from the parent class, which does a lot of
         # work for you.
-        super(self.__class__, self).__init__(
+        super().__init__(
             use_transforms=True,
             params=params,
             expected_params=expected_params,

--- a/pisa/stages/reco/resolutions.py
+++ b/pisa/stages/reco/resolutions.py
@@ -58,19 +58,20 @@ class resolutions(PiStage):
                             )
 
         # init base class
-        super(resolutions, self).__init__(data=data,
-                                        params=params,
-                                        expected_params=expected_params,
-                                        input_names=input_names,
-                                        output_names=output_names,
-                                        debug_mode=debug_mode,
-                                        input_specs=input_specs,
-                                        calc_specs=calc_specs,
-                                        output_specs=output_specs,
-                                        input_calc_keys=input_calc_keys,
-                                        output_calc_keys=output_calc_keys,
-                                        output_apply_keys=output_apply_keys,
-                                       )
+        super().__init__(
+            data=data,
+            params=params,
+            expected_params=expected_params,
+            input_names=input_names,
+            output_names=output_names,
+            debug_mode=debug_mode,
+            input_specs=input_specs,
+            calc_specs=calc_specs,
+            output_specs=output_specs,
+            input_calc_keys=input_calc_keys,
+            output_calc_keys=output_calc_keys,
+            output_apply_keys=output_apply_keys,
+        )
 
         assert self.input_mode is not None
         assert self.calc_mode is None

--- a/pisa/stages/reco/simple_param.py
+++ b/pisa/stages/reco/simple_param.py
@@ -440,17 +440,18 @@ class simple_param(PiStage):
                             )
 
         # init base class
-        super(simple_param, self).__init__(data=data,
-                                        params=params,
-                                        expected_params=expected_params,
-                                        input_names=input_names,
-                                        output_names=output_names,
-                                        debug_mode=debug_mode,
-                                        input_specs=input_specs,
-                                        calc_specs=calc_specs,
-                                        output_specs=output_specs,
-                                        output_apply_keys=output_apply_keys,
-                                       )
+        super().__init__(
+            data=data,
+            params=params,
+            expected_params=expected_params,
+            input_names=input_names,
+            output_names=output_names,
+            debug_mode=debug_mode,
+            input_specs=input_specs,
+            calc_specs=calc_specs,
+            output_specs=output_specs,
+            output_apply_keys=output_apply_keys,
+        )
 
         #TODO Suport other modes
         assert self.input_mode == "events"

--- a/pisa/stages/reco/vbwkde.py
+++ b/pisa/stages/reco/vbwkde.py
@@ -300,7 +300,7 @@ def weight_coszen_tails(cz_diff, cz_bin_edges, input_weights):
     return new_weights, diff_limits
 
 
-@numba_jit(nogil=True, nopython=True, fastmath=True, cache=True)
+#@numba_jit(nogil=True, nopython=True, fastmath=True, cache=True)
 def coszen_error_edges(true_edges, reco_edges):
     """Return a list of edges in coszen-error space given 2 true-coszen
     edges and reco-coszen edges. Systematics are not implemented at this time.

--- a/pisa/stages/reco/vbwkde.py
+++ b/pisa/stages/reco/vbwkde.py
@@ -300,7 +300,7 @@ def weight_coszen_tails(cz_diff, cz_bin_edges, input_weights):
     return new_weights, diff_limits
 
 
-@numba_jit(nogil=True, fastmath=True, cache=True)
+@numba_jit(nogil=True, nopython=True, fastmath=True, cache=True)
 def coszen_error_edges(true_edges, reco_edges):
     """Return a list of edges in coszen-error space given 2 true-coszen
     edges and reco-coszen edges. Systematics are not implemented at this time.
@@ -334,17 +334,17 @@ def coszen_error_edges(true_edges, reco_edges):
     true_bin_midpoint = (true_lower_binedge + true_upper_binedge) / 2
 
     full_reco_range_lower_binedge = np.round(
-        FTYPE(-1) - true_upper_binedge, EQUALITY_SIGFIGS
+        FTYPE(-1) - true_upper_binedge, np.int64(EQUALITY_SIGFIGS)
     )
     full_reco_range_upper_binedge = np.round(
-        FTYPE(+1) - true_lower_binedge, EQUALITY_SIGFIGS
+        FTYPE(+1) - true_lower_binedge, np.int64(EQUALITY_SIGFIGS)
     )
 
     dcz_lower_binedges = np.round(
-        reco_lower_binedges - true_upper_binedge, EQUALITY_SIGFIGS
+        reco_lower_binedges - true_upper_binedge, np.int64(EQUALITY_SIGFIGS)
     )
     dcz_upper_binedges = np.round(
-        reco_upper_binedges - true_lower_binedge, EQUALITY_SIGFIGS
+        reco_upper_binedges - true_lower_binedge, np.int64(EQUALITY_SIGFIGS)
     )
 
     all_dcz_binedges, indices = np.unique(
@@ -835,7 +835,7 @@ class vbwkde(Stage): # pylint: disable=invalid-name
 
         # Invoke the init method from the parent class, which does a lot of
         # work for you.
-        super(vbwkde, self).__init__(
+        super().__init__(
             use_transforms=True,
             params=params,
             expected_params=expected_params,
@@ -848,7 +848,7 @@ class vbwkde(Stage): # pylint: disable=invalid-name
             memcache_deepcopy=memcache_deepcopy,
             input_binning=input_binning,
             output_binning=output_binning,
-            debug_mode=debug_mode
+            debug_mode=debug_mode,
         )
 
         # We have some number of dimensions to characterize (KDE). Each one of
@@ -1493,7 +1493,7 @@ class vbwkde(Stage): # pylint: disable=invalid-name
             pid_total = np.sum(pid_kde_profile.counts)
             if pid_total == 0:
                 pid_fractions = np.zeros(size=len(pid_edges) - 1, dtype=FTYPE)
-                logging.warn('Zero events in PID bin!')
+                logging.warning('Zero events in PID bin!')
             else:
                 pid_norm = 1 / pid_total
                 pid_counts, _ = HIST_FUNC(
@@ -1539,7 +1539,7 @@ class vbwkde(Stage): # pylint: disable=invalid-name
                         shape=len(reco_e_edges) - 1,
                         dtype=FTYPE
                     )
-                    logging.warn('Zero events in energy bin!')
+                    logging.warning('Zero events in energy bin!')
                 else:
                     # TODO: scale about the mode of the KDE! i.e., implement
                     #       `res_scale_ref`

--- a/pisa/stages/unfold/roounfold.py
+++ b/pisa/stages/unfold/roounfold.py
@@ -8,8 +8,9 @@ unfolding.
 
 from __future__ import absolute_import
 
-from operator import add
 from copy import deepcopy
+from functools import reduce
+from operator import add
 
 import numpy as np
 from uncertainties import unumpy as unp
@@ -34,7 +35,6 @@ from pisa.utils.comparisons import normQuant
 from pisa.utils.hash import hash_obj
 from pisa.utils.log import logging
 from pisa.utils.profiler import profile
-from functools import reduce
 
 
 __author__ = 'S. Mandalia'
@@ -120,7 +120,7 @@ class roounfold(Stage):
                 output_str.append(NuFlavIntGroup(name))
         output_str = [str(f) for f in output_str]
 
-        super(self.__class__, self).__init__(
+        super().__init__(
             use_transforms=False,
             params=params,
             expected_params=expected_params,

--- a/pisa/stages/utils/pi_hist.py
+++ b/pisa/stages/utils/pi_hist.py
@@ -57,19 +57,20 @@ class pi_hist(PiStage):
 
 
         # init base class
-        super(pi_hist, self).__init__(data=data,
-                                      params=params,
-                                      expected_params=expected_params,
-                                      input_names=input_names,
-                                      output_names=output_names,
-                                      debug_mode=debug_mode,
-                                      error_method=error_method,
-                                      input_specs=input_specs,
-                                      calc_specs=calc_specs,
-                                      output_specs=output_specs,
-                                      input_apply_keys=input_apply_keys,
-                                      output_apply_keys=output_apply_keys,
-                                     )
+        super().__init__(
+            data=data,
+            params=params,
+            expected_params=expected_params,
+            input_names=input_names,
+            output_names=output_names,
+            debug_mode=debug_mode,
+            error_method=error_method,
+            input_specs=input_specs,
+            calc_specs=calc_specs,
+            output_specs=output_specs,
+            input_apply_keys=input_apply_keys,
+            output_apply_keys=output_apply_keys,
+        )
 
         assert self.input_mode is not None
         assert self.output_mode == 'binned'

--- a/pisa/stages/xsec/genie.py
+++ b/pisa/stages/xsec/genie.py
@@ -11,6 +11,7 @@ $PISA/pisa_examples/resources/settings/pipeline/example_xsec.cfg
 
 from __future__ import absolute_import, division
 
+from functools import reduce
 from itertools import product
 from operator import add
 
@@ -28,7 +29,6 @@ from pisa.utils.hash import hash_obj
 from pisa.utils.log import logging, set_verbosity
 from pisa.utils.profiler import profile
 from pisa.utils.resources import find_resource
-from functools import reduce
 
 
 __all__ = ['genie', 'test_standard_plots', 'test_per_e_plot']
@@ -178,7 +178,7 @@ class genie(Stage): # pylint: disable=invalid-name
         self.transform_groups = [NuFlavIntGroup(flavint)
                                  for flavint in output_names]
 
-        super(genie, self).__init__(
+        super().__init__(
             use_transforms=True,
             params=params,
             expected_params=expected_params,

--- a/pisa/stages/xsec/genie_sys.py
+++ b/pisa/stages/xsec/genie_sys.py
@@ -80,7 +80,7 @@ class genie_sys(PiStage): # pylint: disable=invalid-name
         )
 
         # init base class
-        super(genie_sys, self).__init__(
+        super().__init__(
             data=data,
             params=params,
             expected_params=expected_params,

--- a/pisa/utils/config_parser.py
+++ b/pisa/utils/config_parser.py
@@ -1002,7 +1002,7 @@ class PISAConfigParser(RawConfigParser):
     def __init__(self):
         #self.default_section = None #DEFAULTSECT
         # Instantiate parent class with PISA-specific options
-        #super(PISAConfigParser, self).__init__(
+        #super().__init__(
         RawConfigParser.__init__(
             self,
             interpolation=ExtendedInterpolation(),
@@ -1015,14 +1015,14 @@ class PISAConfigParser(RawConfigParser):
         interpolation syntax on the value."""
         _, option, value = self._validate_value_types(option=option,
                                                       value=value)
-        super(PISAConfigParser, self).set(section, option, value)
+        super().set(section, option, value)
 
     def add_section(self, section):
         """Create a new section in the configuration.  Extends
         RawConfigParser.add_section by validating if the section name is
         a string."""
         section, _, _ = self._validate_value_types(section=section)
-        super(PISAConfigParser, self).add_section(section)
+        super().add_section(section)
 
     def optionxform(self, optionstr):
         """Enable case-sensitive options in .cfg files, and force all values to

--- a/pisa/utils/cross_sections.py
+++ b/pisa/utils/cross_sections.py
@@ -65,7 +65,7 @@ class CrossSections(FlavIntData):
     """
     def __init__(self, ver=None, energy=None,
                  xsec='cross_sections/cross_sections.json'):
-        super(CrossSections, self).__init__()
+        super().__init__()
         self.energy = energy
         self._ver = ver
         self._interpolants = {}
@@ -80,7 +80,7 @@ class CrossSections(FlavIntData):
             raise TypeError('Unhandled xsec type passed in arg: ' +
                             str(type(xsec)))
         if xsec is not None:
-            super(CrossSections, self).validate(xsec)
+            super().validate(xsec)
             self.validate_xsec(self.energy, xsec)
             self.update(xsec)
             self._define_interpolant()

--- a/pisa/utils/data_proc_params.py
+++ b/pisa/utils/data_proc_params.py
@@ -233,7 +233,7 @@ class DataProcParams(dict):
 
     """
     def __init__(self, detector, proc_ver, data_proc_params=None):
-        super(DataProcParams, self).__init__()
+        super().__init__()
         if data_proc_params is None:
             data_proc_params = 'events/data_proc_params.json'
         if isinstance(data_proc_params, str):

--- a/pisa/utils/fileio.py
+++ b/pisa/utils/fileio.py
@@ -5,19 +5,19 @@ Generic file I/O, dispatching specific file readers/writers as necessary
 
 from __future__ import absolute_import
 
-import pickle
 import errno
+from functools import reduce
 import operator
 import os
+import pickle
 import re
+
+import numpy as np
 
 from pisa.utils import hdf
 from pisa.utils import jsons
 from pisa.utils import log
 from pisa.utils import resources
-
-import numpy as np
-from functools import reduce
 
 
 __all__ = [
@@ -155,7 +155,7 @@ def check_file_exists(fname, overwrite=True, warn=True):
     if os.path.exists(fpath):
         if overwrite:
             if warn:
-                log.logging.warn("Overwriting file at '%s'", fpath)
+                log.logging.warning("Overwriting file at '%s'", fpath)
         else:
             raise Exception("Refusing to overwrite path '%s'", fpath)
     return fpath
@@ -180,7 +180,7 @@ def mkdir(d, mode=0o0750, warn=True):
     except OSError as err:
         if err.errno == errno.EEXIST:
             if warn:
-                log.logging.warn('Directory "%s" already exists', d)
+                log.logging.warning('Directory "%s" already exists', d)
         else:
             raise err
     else:

--- a/pisa/utils/fileio.py
+++ b/pisa/utils/fileio.py
@@ -157,7 +157,7 @@ def check_file_exists(fname, overwrite=True, warn=True):
             if warn:
                 log.logging.warning("Overwriting file at '%s'", fpath)
         else:
-            raise Exception("Refusing to overwrite path '%s'", fpath)
+            raise Exception("Refusing to overwrite path '%s'" % fpath)
     return fpath
 
 
@@ -410,8 +410,7 @@ def from_pickle(fname):
 def to_pickle(obj, fname, overwrite=True, warn=True):
     """Save object to a pickle file"""
     check_file_exists(fname=fname, overwrite=overwrite, warn=warn)
-    return pickle.dump(obj, file(fname, 'wb'),
-                        protocol=pickle.HIGHEST_PROTOCOL)
+    return pickle.dump(obj, open(fname, 'wb'), protocol=pickle.HIGHEST_PROTOCOL)
 
 
 def from_txt(fname, as_array=False):

--- a/pisa/utils/flavInt.py
+++ b/pisa/utils/flavInt.py
@@ -38,7 +38,7 @@ from __future__ import absolute_import, division
 
 from collections.abc import MutableSequence, MutableMapping, Mapping, Sequence
 from copy import deepcopy
-from functools import total_ordering
+from functools import reduce, total_ordering
 from itertools import product, combinations
 from operator import add
 import re
@@ -49,7 +49,6 @@ from pisa import ureg
 from pisa.utils import fileio
 from pisa.utils.log import logging, set_verbosity
 from pisa.utils.comparisons import recursiveAllclose, recursiveEquality
-from functools import reduce
 
 
 __all__ = ['NuFlav', 'NuFlavInt', 'NuFlavIntGroup', 'FlavIntData',
@@ -1191,7 +1190,7 @@ class FlavIntData(dict):
 
     """
     def __init__(self, val=None):
-        super(FlavIntData, self).__init__()
+        super().__init__()
         if isinstance(val, str):
             d = self.__load(val)
         elif isinstance(val, dict):
@@ -1224,7 +1223,7 @@ class FlavIntData(dict):
     def __getitem__(self, *args):
         assert len(args) <= 2
         key_list = self._interpret_index(args)
-        tgt_obj = super(FlavIntData, self).__getitem__(key_list[0])
+        tgt_obj = super().__getitem__(key_list[0])
         if len(key_list) == 2:
             tgt_obj = tgt_obj[key_list[1]]
         return tgt_obj
@@ -1399,7 +1398,7 @@ class FlavIntDataGroup(dict):
             interpreted as a NuFlavIntGroup.
     """
     def __init__(self, val=None, flavint_groups=None):
-        super(FlavIntDataGroup, self).__init__()
+        super().__init__()
         self._flavint_groups = None
         if flavint_groups is None:
             if val is None:
@@ -1602,14 +1601,14 @@ class FlavIntDataGroup(dict):
 
     def __getitem__(self, arg):
         key = self._interpret_index(arg)
-        tgt_obj = super(FlavIntDataGroup, self).__getitem__(key)
+        tgt_obj = super().__getitem__(key)
         return tgt_obj
 
     def __setitem__(self, arg, value):
         key = self._interpret_index(arg)
         if NuFlavIntGroup(key) not in self.flavint_groups:
             self.flavint_groups += [NuFlavIntGroup(key)]
-        super(FlavIntDataGroup, self).__setitem__(key, value)
+        super().__setitem__(key, value)
 
     def __eq__(self, other):
         """Recursive, exact equality"""
@@ -1766,8 +1765,10 @@ class CombinedFlavIntData(FlavIntData):
 
         elif val is None:
             if flavint_groupings is None:
-                logging.warn('CombinedFlavIntData object instantiated without'
-                             ' flavint groupings specified.')
+                logging.warning(
+                    'CombinedFlavIntData object instantiated without'
+                    ' flavint groupings specified.'
+                )
             named_g = grouped
             named_ung = ungrouped
             # Instantiate empty dict with groupings as keys
@@ -1806,10 +1807,10 @@ class CombinedFlavIntData(FlavIntData):
         return recursiveEquality(self, other)
 
     #def __getitem__(self, item):
-    #    return super(CombinedFlavIntData, self).__getitem__(item)
+    #    return super().__getitem__(item)
 
     #def __setitem__(self, item, value):
-    #    return super(CombinedFlavIntData, self).__setitem__(item, value)
+    #    return super().__setitem__(item, value)
 
     def deduplicate(self, rtol=None, atol=None):
         """Identify duplicate datasets and combine the associated flavints

--- a/pisa/utils/hdf.py
+++ b/pisa/utils/hdf.py
@@ -84,7 +84,7 @@ def from_hdf(val, return_node=None, return_attrs=False):
         """Iteratively parse `obj` to create the dictionary `sdict`"""
         name = obj.name.split('/')[-1]
         if isinstance(obj, h5py.Dataset):
-            sdict[name] = obj.value
+            sdict[name] = obj[()]
         if isinstance(obj, (h5py.Group, h5py.File)):
             sdict[name] = OrderedDict()
             for sobj in obj.values():
@@ -188,8 +188,10 @@ def to_hdf(data_dict, tgt, attrs=None, overwrite=True, warn=True):
                     key_str = key
                 else:
                     key_str = str(key)
-                    logging.warn('Making string from key "%s", %s for use as'
-                                 ' name in HDF5 file', key_str, type(key))
+                    logging.warning(
+                        'Making string from key "%s", %s for use as'
+                        ' name in HDF5 file', key_str, type(key)
+                    )
                 val = node[key]
                 new_path = path + [key_str]
                 store_recursively(fhandle=fhandle, node=val, path=new_path,
@@ -207,8 +209,10 @@ def to_hdf(data_dict, tgt, attrs=None, overwrite=True, warn=True):
             # None
             if node is None:
                 node = np.nan
-                logging.warn('  encountered `None` at node "%s"; converting to'
-                             ' np.nan', full_path)
+                logging.warning(
+                    '  encountered `None` at node "%s"; converting to'
+                    ' np.nan', full_path
+                )
             # "Scalar datasets don't support chunk/filter options". Shuffling
             # is a good idea otherwise since subsequent compression will
             # generally benefit; shuffling requires chunking. Compression is
@@ -277,7 +281,7 @@ def to_hdf(data_dict, tgt, attrs=None, overwrite=True, warn=True):
         store_recursively(fhandle=tgt, node=data_dict, attrs=attrs)
 
     else:
-        raise TypeError('to_hdf: Invalid `tgt` type: %s', type(tgt))
+        raise TypeError('to_hdf: Invalid `tgt` type: %s' % type(tgt))
 
 
 def test_hdf():

--- a/pisa/utils/jsons.py
+++ b/pisa/utils/jsons.py
@@ -245,7 +245,7 @@ class NumpyDecoder(json.JSONDecoder):
     def __init__(self, encoding=None, object_hook=None, parse_float=None,
                  parse_int=None, parse_constant=None, strict=True,
                  object_pairs_hook=None):
-        super(NumpyDecoder, self).__init__(
+        super().__init__(
             encoding=encoding, object_hook=object_hook,
             parse_float=parse_float, parse_int=parse_int,
             parse_constant=parse_constant, strict=strict,

--- a/pisa/utils/kde_hist.py
+++ b/pisa/utils/kde_hist.py
@@ -375,8 +375,9 @@ def test_kde_histogramdd():
         rmtree(temp_dir)
         raise
     else:
-        logging.warn('Inspect and manually clean up output(s) saved to %s'
-                     % temp_dir)
+        logging.warning(
+            'Inspect and manually clean up output(s) saved to %s' % temp_dir
+        )
 
 
 if __name__ == '__main__':

--- a/pisa/utils/mcSimRunSettings.py
+++ b/pisa/utils/mcSimRunSettings.py
@@ -124,7 +124,7 @@ class MCSimRunSettings(dict):
 
     """
     def __init__(self, run_settings, run=None, detector=None):
-        super(MCSimRunSettings, self).__init__()
+        super().__init__()
         # TODO: clean up this constructor!
         #if isinstance(run_settings, str):
         #    rsd = jsons.from_json(resources.find_resource(run_settings))
@@ -307,7 +307,7 @@ class DetMCSimRunsSettings(dict):
 
     """
     def __init__(self, run_settings, detector=None):
-        super(DetMCSimRunsSettings, self).__init__()
+        super().__init__()
         if isinstance(run_settings, str):
             rsd = fileio.from_file(resources.find_resource(run_settings))
         elif isinstance(run_settings, dict):

--- a/pisa/utils/parallel.py
+++ b/pisa/utils/parallel.py
@@ -10,13 +10,13 @@ multiple processes.
 from __future__ import division
 
 from copy import copy
-import Queue
+from functools import reduce
+import queue
 import threading
 import time
 
 from pisa import OMP_NUM_THREADS
 from pisa.utils.log import logging, set_verbosity
-from functools import reduce
 
 
 __all__ = ['parallel_run']
@@ -46,7 +46,7 @@ def wrapper(func, retvals_queue, chunk):
     Parameters
     ----------
     func : callable
-    retvals_queue : Queue.Queue
+    retvals_queue : queue.Queue
     chunk : dict containing {'args': (...), 'kwargs': {...}}
 
     """
@@ -177,7 +177,7 @@ def parallel_run(func, kind, num_parallel, scalar_func, divided_args_mask,
                 has_str = 'all have'
             else:
                 has_str = 'has'
-            logging.error('%s%s %s length %d', pargstr, pkwargsstr, has_str,
+            logging.error('%s%s %s length %d', pargstr, pkwargstr, has_str,
                           length)
 
         raise ValueError('Each divided arg and each divided keyword arg must'
@@ -237,7 +237,7 @@ def parallel_run(func, kind, num_parallel, scalar_func, divided_args_mask,
                 else:
                     worker_kwargs[name] = val
 
-            chunk = dict(indices=range(start_ind, end_ind),
+            chunk = dict(indices=list(range(start_ind, end_ind)),
                          args=tuple(worker_args),
                          kwargs=worker_kwargs)
             chunks.append(chunk)
@@ -250,7 +250,7 @@ def parallel_run(func, kind, num_parallel, scalar_func, divided_args_mask,
                 ' items', batch_num + 1, len(chunks), items_in_batch
             )
 
-            return_values = Queue.Queue()
+            return_values = queue.Queue()
             threads = []
             for chunk in chunks:
                 thread = threading.Thread(

--- a/pisa/utils/postprocess.py
+++ b/pisa/utils/postprocess.py
@@ -1168,7 +1168,7 @@ class Postprocessor(object):
                 good_trials = modified_z_score < thresh
                 if not np.all(good_trials):
                     bad_trials = np.where(not good_trials)[0]
-                    logging.warn(
+                    logging.warning(
                         'Outlier(s) detected for %s in trial(s) %s. Will be '
                         'removed. If you think this should not happen, please '
                         'change the value of the threshold used for the '
@@ -1508,13 +1508,13 @@ class Postprocessor(object):
                 )
             try:
                 import matplotlib.patheffects as PathEffects
-                logging.warn(
+                logging.warning(
                     "PathEffects could be imported, so the correlation values"
                     " will be written on the bins. This is slow."
                 )
                 pe = True
             except ImportError:
-                logging.warn(
+                logging.warning(
                     "PathEffects could not be imported, so the correlation"
                     " values will not be written on the bins.")
                 pe = False
@@ -4021,7 +4021,7 @@ class Postprocessor(object):
             bin_cens = []
             if isinstance(all_steps[step_variable][0][1], list):
                 if len(all_steps[step_variable][0][1]) == 0:
-                    logging.warn(
+                    logging.warning(
                         "No units have been found for the scan "
                         "parameter. Making it dimensionless."
                     )
@@ -5054,14 +5054,14 @@ class Postprocessor(object):
     def get_correlation_coefficient(self, xdata, ydata, xsystkey, ysystkey):
         """Calculate the correlation coefficient between x and y"""
         if len(set(xdata)) == 1:
-            logging.warn(
+            logging.warning(
                 "Parameter %s appears to not have been varied. "
                 "i.e. all of the values in the set are the "
                 "same. This will lead to NaN in the correlation "
                 "calculation and so it will not be done."%xsystkey
             )
         if len(set(ydata)) == 1:
-            logging.warn(
+            logging.warning(
                 "Parameter %s appears to not have been varied. "
                 "i.e. all of the values in the set are the "
                 "same. This will lead to NaN in the correlation "
@@ -5239,8 +5239,7 @@ class Postprocessor(object):
         pretty_labels["livetime"] = r"Livetime"
         pretty_labels["julian_year"] = r"Years"
         if label not in pretty_labels.keys():
-            logging.warn("I have no nice label for %s. "
-                         "Returning as is."%label)
+            logging.warning("I have no nice label for %s. Returning as is."%label)
             return label
         return pretty_labels[label]
 

--- a/pisa/utils/spline.py
+++ b/pisa/utils/spline.py
@@ -191,7 +191,7 @@ class CombinedSpline(flavInt.FlavIntData):
 
     """
     def __init__(self, inSpline, interactions=True, ver=None):
-        super(CombinedSpline, self).__init__()
+        super().__init__()
         self.interactions = interactions
 
         if isinstance(inSpline, Spline):
@@ -310,7 +310,7 @@ class CombinedSpline(flavInt.FlavIntData):
                                 self._spline_data[x]
                     else:
                         spline[str(x)][str(y)] = self._spline_data[x]
-        super(CombinedSpline, self).validate(spline)
+        super().validate(spline)
         self.validate_spline(spline)
         self.update(spline)
 
@@ -325,7 +325,7 @@ class CombinedSpline(flavInt.FlavIntData):
         for signature in self._spline_data.keys():
             if self._spline_data[signature].name == sign:
                 return self._spline_data[signature]
-        return super(CombinedSpline, self).__getattribute__(sign)
+        return super().__getattribute__(sign)
 
     def _validate_NuFlav(self, signature):
         if self.interactions:

--- a/pisa/utils/tests.py
+++ b/pisa/utils/tests.py
@@ -329,8 +329,10 @@ def plot_comparisons(ref_map, new_map, ref_abv, new_abv, outdir, subdir, name,
     # This isn't necessarily a fail, since all it means is the referene was
     # zero If the new value is sufficiently close to zero then it's still fine
     if max_diff_ratio == float('inf'):
-        logging.warn('Infinite value found in ratio tests. Difference tests '
-                     'now also being calculated')
+        logging.warning(
+            'Infinite value found in ratio tests. Difference tests '
+            'now also being calculated'
+        )
         # First find all the finite elements
         finite_map = np.isfinite(diff_ratio_map['map'])
         # Then find the nanmax of this, will be our new test value
@@ -439,8 +441,10 @@ def plot_map_comparisons(ref_map, new_map, ref_abv, new_abv, outdir, subdir,
     # This isn't necessarily a fail, since all it means is the referene was
     # zero If the new value is sufficiently close to zero then it's still fine
     if max_diff_ratio == float('inf'):
-        logging.warn('Infinite value found in ratio tests. Difference tests '
-                     'now also being calculated')
+        logging.warning(
+            'Infinite value found in ratio tests. Difference tests '
+            'now also being calculated'
+        )
         # First find all the finite elements
         finite_map = np.isfinite(diff_ratio_map.hist)
         # Then find the nanmax of this, will be our new test value
@@ -591,8 +595,10 @@ def plot_cmp(new, ref, new_label, ref_label, plot_label, file_label, outdir,
         # zero. If the new value is sufficiently close to zero then it's stil
         # fine.
         if max_diff_ratio == np.inf:
-            logging.warn('Infinite value found in ratio tests. Difference tests'
-                         ' now also being calculated')
+            logging.warning(
+                'Infinite value found in ratio tests. Difference tests'
+                ' now also being calculated'
+            )
             # First find all the finite elements
             finite_mask = np.isfinite(fract_diff.hist)
             # Then find the nanmax of this, will be our new test value
@@ -721,13 +727,13 @@ def pisa2_map_to_pisa3_map(pisa2_map, ebins_name='ebins', czbins_name='czbins',
         name=ebins_name,
         bin_edges=pisa2_map['ebins'] * ureg.GeV,
         is_log=is_log,
-        tex='E_{\nu}'
+        tex=r'E_{\nu}'
     )
     czbins = OneDimBinning(
         name=czbins_name,
         bin_edges=pisa2_map['czbins'],
         is_lin=is_lin,
-        tex='\cos\theta_Z'
+        tex=r'\cos\theta_Z'
     )
     bins = MultiDimBinning([ebins, czbins])
     return Map(

--- a/pisa/utils/vbwkde.py
+++ b/pisa/utils/vbwkde.py
@@ -159,7 +159,7 @@ def fbwkde(data, weights=None, n_dct=None, min=None, max=None,
 
     # Histogram the data to get a crude first approximation of the density
     data_hist, bins = np.histogram(
-        data, bins=n_dct, range=(min, max), normed=False, weights=weights
+        data, bins=n_dct, range=(min, max), density=False, weights=weights
     )
 
     # Make into a probability mass function

--- a/pisa_tests/test_changes_with_combined_pidreco.py
+++ b/pisa_tests/test_changes_with_combined_pidreco.py
@@ -403,8 +403,10 @@ def main():
     known_weights = [None, 'weighted_aeff']
 
     if args.weighting not in known_weights:
-        logging.warn('''%s weighting field not known to be in events file.
-                     Tests may not work in this case!'''%args.weighting)
+        logging.warning(
+            '''%s weighting field not known to be in events file.
+            Tests may not work in this case!'''%args.weighting
+        )
 
     # Want these for all tests
     pisa_standard_settings = os.path.join(

--- a/pisa_tests/test_command_lines.sh
+++ b/pisa_tests/test_command_lines.sh
@@ -260,7 +260,7 @@ echo "Storing results to"
 echo "  $OUTDIR"
 echo "=============================================================================="
 PISA_FTYPE=float32 python $PISA/pisa/scripts/analysis.py discrete_hypo \
-	--h0-pipeline settings/pipeline/example_gpu.cfg \
+	--h0-pipeline settings/pipeline/example.cfg \
 	--h0-param-selections="ih" \
 	--h1-param-selections="nh" \
 	--data-param-selections="nh" \

--- a/pisa_tests/test_example_pipelines.py
+++ b/pisa_tests/test_example_pipelines.py
@@ -119,7 +119,7 @@ def test_example_pipelines(ignore_gpu=False, ignore_root=False,
         finally:
             if exc is not None:
                 if allow_error:
-                    logging.warn(msg)
+                    logging.warning(msg)
                 else:
                     logging.error(
                         '    FAILURE! %s failed to run. Please review the'
@@ -133,8 +133,10 @@ def test_example_pipelines(ignore_gpu=False, ignore_root=False,
                 logging.info('    Seems fine!')
 
     if skip_count > 0:
-        logging.warn('%d of %d example pipeline config files were skipped',
-                     skip_count, num_configs)
+        logging.warning(
+            '%d of %d example pipeline config files were skipped',
+            skip_count, num_configs
+        )
 
     if failure_count > 0:
         msg = ('<< FAIL : test_example_pipelines : (%d of %d EXAMPLE PIPELINE'


### PR DESCRIPTION
* `super(self.__class__, self)` or `super(*, self)` -> `super()`
* `range(...)` -> `list(range(...))` where appropriate (same for `zip`)
* reorder imports (note ordering used in general is future, built-ins, standard external modules, then internal modules)
* `file` -> `open`
* bugfixes found while fixing the above:
  * % formatting
  * numba failed to compile function; simply removed numba-jit of that function
* reference to no-longer-existing cfg file in `test_command_lines.sh`
* `1e5` -> `int(1e5)`